### PR TITLE
getGameRatioEachPlatform API 추가 

### DIFF
--- a/src/main/java/com/game/rmt/domain/platform/repository/custom/PlatformRepositoryCustom.java
+++ b/src/main/java/com/game/rmt/domain/platform/repository/custom/PlatformRepositoryCustom.java
@@ -2,6 +2,9 @@ package com.game.rmt.domain.platform.repository.custom;
 
 import com.game.rmt.domain.platform.domain.Platform;
 
+import java.util.List;
+
 public interface PlatformRepositoryCustom {
     Platform findPlatformById(Long id);
+    List<Platform> findPlatformByIds(List<Long> ids);
 }

--- a/src/main/java/com/game/rmt/domain/platform/repository/custom/PlatformRepositoryImpl.java
+++ b/src/main/java/com/game/rmt/domain/platform/repository/custom/PlatformRepositoryImpl.java
@@ -2,9 +2,12 @@ package com.game.rmt.domain.platform.repository.custom;
 
 import com.game.rmt.domain.platform.domain.Platform;
 import com.game.rmt.domain.platform.domain.QPlatform;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import javax.persistence.EntityManager;
+
+import java.util.List;
 
 import static com.game.rmt.domain.platform.domain.QPlatform.platform;
 
@@ -21,7 +24,24 @@ public class PlatformRepositoryImpl implements PlatformRepositoryCustom {
         return queryFactory
                 .select(platform)
                 .from(platform)
-                .where(platform.id.eq(id))
+                .where(eqPlatformId(id))
                 .fetchFirst();
+    }
+
+    @Override
+    public List<Platform> findPlatformByIds(List<Long> ids) {
+        return queryFactory
+                .select(platform)
+                .from(platform)
+                .where(eqPlatformIds(ids))
+                .fetch();
+    }
+
+    private BooleanExpression eqPlatformId(long platformId) {
+        return platform.id.eq(platformId);
+    }
+
+    private BooleanExpression eqPlatformIds(List<Long> platformIds) {
+        return platform.id.in(platformIds);
     }
 }

--- a/src/main/java/com/game/rmt/domain/platform/service/PlatformService.java
+++ b/src/main/java/com/game/rmt/domain/platform/service/PlatformService.java
@@ -38,6 +38,16 @@ public class PlatformService {
         return platform;
     }
 
+    public List<Platform> getPlatforms(List<Long> ids) {
+        List<Platform> platformList = platformRepository.findPlatformByIds(ids);
+
+        if (platformList.isEmpty()) {
+            throw new NotFoundException(NOT_FOUND_PLATFORM);
+        }
+
+        return platformList;
+    }
+
     private List<PlatformDTO> convertPlatformDTOList(List<Platform> platformList) {
         List<PlatformDTO> platformDTOList = new ArrayList<>();
 

--- a/src/main/java/com/game/rmt/domain/statistics/controller/StatisticsController.java
+++ b/src/main/java/com/game/rmt/domain/statistics/controller/StatisticsController.java
@@ -1,5 +1,7 @@
 package com.game.rmt.domain.statistics.controller;
 
+import com.game.rmt.domain.statistics.dto.request.GameRatioEachPlatformRequest;
+import com.game.rmt.domain.statistics.dto.response.GameRatioEachPlatformResponse;
 import com.game.rmt.domain.statistics.dto.response.MonthlyEachGameResponse;
 import com.game.rmt.domain.statistics.dto.request.MonthlyGameRequest;
 import com.game.rmt.domain.statistics.dto.request.MonthlyPlatformRequest;
@@ -25,5 +27,10 @@ public class StatisticsController {
     @GetMapping("/monthly/platform")
     public MonthlyEachGameResponse getMonthlyPlatformStatics(@RequestBody MonthlyPlatformRequest request) {
         return statisticsService.getMonthlyPlatformStatics(request);
+    }
+
+    @GetMapping("/ratio/game")
+    public GameRatioEachPlatformResponse getGameRatioEachPlatform(@RequestBody GameRatioEachPlatformRequest request) {
+        return statisticsService.getGameRatioEachPlatform(request);
     }
 }

--- a/src/main/java/com/game/rmt/domain/statistics/dto/GamePriceDTO.java
+++ b/src/main/java/com/game/rmt/domain/statistics/dto/GamePriceDTO.java
@@ -6,12 +6,12 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
-public class GameTotalPriceDTO {
+public class GamePriceDTO {
     private String gameName;
     private Integer price;
 
     @QueryProjection
-    public GameTotalPriceDTO(String gameName, Integer price) {
+    public GamePriceDTO(String gameName, Integer price) {
         this.gameName = gameName;
         this.price = price;
     }

--- a/src/main/java/com/game/rmt/domain/statistics/dto/GameRatioDTO.java
+++ b/src/main/java/com/game/rmt/domain/statistics/dto/GameRatioDTO.java
@@ -1,4 +1,4 @@
-package com.game.rmt.domain.statistics.dto.response;
+package com.game.rmt.domain.statistics.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/src/main/java/com/game/rmt/domain/statistics/dto/request/GameRatioEachPlatformRequest.java
+++ b/src/main/java/com/game/rmt/domain/statistics/dto/request/GameRatioEachPlatformRequest.java
@@ -1,5 +1,6 @@
 package com.game.rmt.domain.statistics.dto.request;
 
+import com.game.rmt.domain.statistics.dto.RangeDate;
 import com.game.rmt.global.errorhandler.exception.BadRequestException;
 import com.game.rmt.global.parent.CreateRequest;
 import lombok.AllArgsConstructor;
@@ -14,30 +15,38 @@ import static com.game.rmt.global.errorhandler.exception.ErrorCode.BAD_REQUEST_G
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor
-public class EachGameRatioRequest implements CreateRequest {
+public class GameRatioEachPlatformRequest implements CreateRequest {
     private List<Long> platformIds;
     private LocalDate startDate;
     private LocalDate endDate;
 
     @Override
     public void isValidParam() {
-        if (isValidDate()) {
+        if (isValidPlatformIds() && isValidDate()) {
             return;
         }
 
         throw new BadRequestException(BAD_REQUEST_GET_STATISTICS);
     }
 
-    public boolean isValidRangeDate() {
-        return isNotNullRangeDate() && isBeforeDate();
+    public RangeDate getRangeDateCondition() {
+        if (isValidRangeDate()) {
+            return RangeDate.RANGE_DATE;
+        }
+
+        if (isOnlyStartDate()) {
+            return RangeDate.ONLY_START_DATE;
+        }
+
+        if (isOnlyEndDate()) {
+            return RangeDate.ONLY_END_DATE;
+        }
+
+        return RangeDate.NONE;
     }
 
-    public boolean isOnlyStartDate() {
-        return isNotNull(startDate) && !isNotNull(endDate);
-    }
-
-    public boolean isOnlyEndDate() {
-        return !isNotNull(startDate) && isNotNull(endDate);
+    private boolean isValidPlatformIds() {
+        return isNotNull(platformIds) && !platformIds.isEmpty();
     }
 
     private boolean isValidDate() {
@@ -50,5 +59,17 @@ public class EachGameRatioRequest implements CreateRequest {
 
     private boolean isBeforeDate() {
         return startDate.isBefore(endDate);
+    }
+
+    private boolean isValidRangeDate() {
+        return isNotNullRangeDate() && isBeforeDate();
+    }
+
+    private boolean isOnlyStartDate() {
+        return isNotNull(startDate) && !isNotNull(endDate);
+    }
+
+    private boolean isOnlyEndDate() {
+        return !isNotNull(startDate) && isNotNull(endDate);
     }
 }

--- a/src/main/java/com/game/rmt/domain/statistics/dto/request/MonthlyGameRequest.java
+++ b/src/main/java/com/game/rmt/domain/statistics/dto/request/MonthlyGameRequest.java
@@ -35,18 +35,6 @@ public class MonthlyGameRequest implements CreateRequest {
         throw new BadRequestException(BAD_REQUEST_GET_STATISTICS);
     }
 
-    public boolean isValidRangeDate() {
-        return isNotNullRangeDate() && isBeforeDate();
-    }
-
-    public boolean isOnlyStartDate() {
-        return isNotNull(startDate) && !isNotNull(endDate);
-    }
-
-    public boolean isOnlyEndDate() {
-        return !isNotNull(startDate) && isNotNull(endDate);
-    }
-
     public RangeDate getRangeDateCondition() {
         if (isValidRangeDate()) {
             return RangeDate.RANGE_DATE;
@@ -73,5 +61,17 @@ public class MonthlyGameRequest implements CreateRequest {
 
     private boolean isBeforeDate() {
         return startDate.isBefore(endDate);
+    }
+
+    private boolean isValidRangeDate() {
+        return isNotNullRangeDate() && isBeforeDate();
+    }
+
+    private boolean isOnlyStartDate() {
+        return isNotNull(startDate) && !isNotNull(endDate);
+    }
+
+    private boolean isOnlyEndDate() {
+        return !isNotNull(startDate) && isNotNull(endDate);
     }
 }

--- a/src/main/java/com/game/rmt/domain/statistics/dto/request/MonthlyPlatformRequest.java
+++ b/src/main/java/com/game/rmt/domain/statistics/dto/request/MonthlyPlatformRequest.java
@@ -29,18 +29,6 @@ public class MonthlyPlatformRequest implements CreateRequest {
         throw new BadRequestException(BAD_REQUEST_GET_STATISTICS);
     }
 
-    public boolean isValidRangeDate() {
-        return isNotNullRangeDate() && isBeforeDate();
-    }
-
-    public boolean isOnlyStartDate() {
-        return isNotNull(startDate) && !isNotNull(endDate);
-    }
-
-    public boolean isOnlyEndDate() {
-        return !isNotNull(startDate) && isNotNull(endDate);
-    }
-
     public RangeDate getRangeDateCondition() {
         if (isValidRangeDate()) {
             return RangeDate.RANGE_DATE;
@@ -67,5 +55,17 @@ public class MonthlyPlatformRequest implements CreateRequest {
 
     private boolean isBeforeDate() {
         return startDate.isBefore(endDate);
+    }
+
+    private boolean isValidRangeDate() {
+        return isNotNullRangeDate() && isBeforeDate();
+    }
+
+    private boolean isOnlyStartDate() {
+        return isNotNull(startDate) && !isNotNull(endDate);
+    }
+
+    private boolean isOnlyEndDate() {
+        return !isNotNull(startDate) && isNotNull(endDate);
     }
 }

--- a/src/main/java/com/game/rmt/domain/statistics/dto/response/GameRatioEachPlatformResponse.java
+++ b/src/main/java/com/game/rmt/domain/statistics/dto/response/GameRatioEachPlatformResponse.java
@@ -1,0 +1,16 @@
+package com.game.rmt.domain.statistics.dto.response;
+
+import com.game.rmt.domain.statistics.dto.GameRatioDTO;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class GameRatioEachPlatformResponse {
+    private List<String> platformNames;
+    private List<GameRatioDTO> gameRatioList;
+}

--- a/src/main/java/com/game/rmt/domain/statistics/service/StatisticsService.java
+++ b/src/main/java/com/game/rmt/domain/statistics/service/StatisticsService.java
@@ -106,10 +106,6 @@ public class StatisticsService {
         };
     }
 
-    private List<MonthlyStaticsDTO> getMonthlyStaticsByPlatformId(MonthlyPlatformRequest request) {
-        return staticsRepository.findMonthlyStaticsByPlatformId(request.getPlatformId());
-    }
-
     private List<MonthlyStaticsDTO> getMonthlyStaticsByPlatformIdBetweenDate(MonthlyPlatformRequest request) {
         return staticsRepository.findMonthlyStaticsByPlatformIdBetweenDate(
                 request.getPlatformId(),

--- a/src/main/java/com/game/rmt/domain/statistics/service/StatisticsService.java
+++ b/src/main/java/com/game/rmt/domain/statistics/service/StatisticsService.java
@@ -4,6 +4,10 @@ import com.game.rmt.domain.game.domain.Game;
 import com.game.rmt.domain.game.service.GameService;
 import com.game.rmt.domain.platform.domain.Platform;
 import com.game.rmt.domain.platform.service.PlatformService;
+import com.game.rmt.domain.statistics.dto.GamePriceDTO;
+import com.game.rmt.domain.statistics.dto.GameRatioDTO;
+import com.game.rmt.domain.statistics.dto.request.GameRatioEachPlatformRequest;
+import com.game.rmt.domain.statistics.dto.response.GameRatioEachPlatformResponse;
 import com.game.rmt.domain.statistics.dto.response.MonthlyEachGameResponse;
 import com.game.rmt.domain.statistics.dto.request.MonthlyGameRequest;
 import com.game.rmt.domain.statistics.dto.request.MonthlyPlatformRequest;
@@ -12,7 +16,9 @@ import com.game.rmt.domain.statistics.repository.custom.StaticsRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 
 @Service
@@ -38,12 +44,31 @@ public class StatisticsService {
         return new MonthlyEachGameResponse(findPlatform.getName(), monthlyStatics);
     }
 
+    public GameRatioEachPlatformResponse getGameRatioEachPlatform(GameRatioEachPlatformRequest request) {
+        List<Platform> platformList = validateGameRatioEachPlatform(request);
+        List<GamePriceDTO> gamePriceDTOList = getPriceEachGameByCondition(request);
+
+        if (gamePriceDTOList == null || gamePriceDTOList.isEmpty()) {
+            return new GameRatioEachPlatformResponse(
+                    getPlatformNames(platformList),
+                    new ArrayList<>());
+        }
+
+        return new GameRatioEachPlatformResponse(
+                getPlatformNames(platformList),
+                convertRatioList(gamePriceDTOList, sumTotalPrice(gamePriceDTOList))
+        );
+    }
+
+    private List<Platform> validateGameRatioEachPlatform(GameRatioEachPlatformRequest request) {
+        request.isValidParam();
+        return platformService.getPlatforms(request.getPlatformIds());
+    }
+
     private Platform validateMonthlyPlatformStatics(MonthlyPlatformRequest request) {
         request.isValidParam();
         return platformService.getPlatform(request.getPlatformId());
     }
-
-
 
     private Game validateMonthlyGameStatics(MonthlyGameRequest request) {
         request.isValidParam();
@@ -114,5 +139,58 @@ public class StatisticsService {
             case ONLY_END_DATE -> getMonthlyStaticsByPlatformIdAndEndDate(request);
             default -> staticsRepository.findMonthlyStaticsByPlatformId(request.getPlatformId());
         };
+    }
+
+    private List<GamePriceDTO> getPriceEachGameByPlatformsAndStartDate(GameRatioEachPlatformRequest request) {
+        return staticsRepository.findPriceEachGameByPlatformsAndStartDate(
+                request.getPlatformIds(),
+                request.getStartDate()
+        );
+    }
+
+    private List<GamePriceDTO> getPriceEachGameByPlatformsAndEndDate(GameRatioEachPlatformRequest request) {
+        return staticsRepository.findPriceEachGameByPlatformsAndEndDate(
+                request.getPlatformIds(),
+                request.getEndDate()
+        );
+    }
+
+    private List<GamePriceDTO> getPriceEachGameByPlatformsBetweenDate(GameRatioEachPlatformRequest request) {
+        return staticsRepository.findPriceEachGameByPlatformsBetweenDate(
+                request.getPlatformIds(),
+                request.getStartDate(),
+                request.getEndDate()
+        );
+    }
+
+    private List<GamePriceDTO> getPriceEachGameByCondition(GameRatioEachPlatformRequest request) {
+        return switch (request.getRangeDateCondition()) {
+            case RANGE_DATE -> getPriceEachGameByPlatformsBetweenDate(request);
+            case ONLY_START_DATE -> getPriceEachGameByPlatformsAndStartDate(request);
+            case ONLY_END_DATE -> getPriceEachGameByPlatformsAndEndDate(request);
+            default -> staticsRepository.findPriceEachGameByPlatforms(request.getPlatformIds());
+        };
+    }
+
+    private double sumTotalPrice(List<GamePriceDTO> priceDTOList) {
+        return priceDTOList.stream()
+                .mapToDouble(GamePriceDTO::getPrice)
+                .sum();
+    }
+
+    private List<GameRatioDTO> convertRatioList(List<GamePriceDTO> priceDTOList, double totalPrice) {
+        List<GameRatioDTO> gameRatioDTOList = new ArrayList<>();
+
+        for (GamePriceDTO priceDTO : priceDTOList) {
+            gameRatioDTOList.add(new GameRatioDTO(priceDTO.getGameName(), totalPrice, priceDTO.getPrice()));
+        }
+
+        return gameRatioDTOList;
+    }
+
+    private List<String> getPlatformNames(List<Platform> platformList) {
+        return platformList.stream()
+                .map(Platform::getName)
+                .collect(Collectors.toList());
     }
 }

--- a/src/test/java/com/game/rmt/domain/statistics/service/StatisticsServiceTest.java
+++ b/src/test/java/com/game/rmt/domain/statistics/service/StatisticsServiceTest.java
@@ -10,10 +10,10 @@ import com.game.rmt.domain.platform.service.PlatformService;
 import com.game.rmt.domain.product.domain.Product;
 import com.game.rmt.domain.product.repository.ProductRepository;
 import com.game.rmt.domain.statistics.dto.*;
-import com.game.rmt.domain.statistics.dto.request.EachGameRatioRequest;
+import com.game.rmt.domain.statistics.dto.request.GameRatioEachPlatformRequest;
 import com.game.rmt.domain.statistics.dto.request.MonthlyGameRequest;
 import com.game.rmt.domain.statistics.dto.request.MonthlyPlatformRequest;
-import com.game.rmt.domain.statistics.dto.response.GameRatioDTO;
+import com.game.rmt.domain.statistics.dto.GameRatioDTO;
 import com.game.rmt.domain.statistics.dto.response.MonthlyEachGameResponse;
 import com.game.rmt.domain.statistics.dto.response.MonthlyEachPlatformResponse;
 import com.game.rmt.global.errorhandler.exception.ErrorCode;
@@ -374,10 +374,10 @@ class StatisticsServiceTest {
     public void getRatioEachGame() {
         // 통계 기반 정보 받아오기 : platformIds, startDate, endDate
         List<Long> platformIds = Arrays.asList((long) 1, (long) 2);
-        EachGameRatioRequest request = new EachGameRatioRequest(platformIds, null, null);
+        GameRatioEachPlatformRequest request = new GameRatioEachPlatformRequest(platformIds, null, null);
         // 통계 기반 정보 유효성 체크
         request.isValidParam();
-        // platformIds의 length가 0일 경우(또는 null) 전체 플랫폼으로 조회 -> 이 때, platform 테이블은 조인하지 않음
+        // platformIds의 length가 0일 경우(또는 null) 반려
         // platformIds가 없으면서 전체 기간이 없을 경우
         /*select g.name, sum(account.price)
         from account
@@ -385,16 +385,16 @@ class StatisticsServiceTest {
         right join game g on g.id = p.game_id
         group by game_id;
         */
-        List<GameTotalPriceDTO> fetch = queryFactory
-                .select(new QGameTotalPriceDTO(game.name, account.price.sum()))
+        List<GamePriceDTO> fetch = queryFactory
+                .select(new QGamePriceDTO(game.name, account.price.sum()))
                 .from(account)
                 .join(account.product, product)
                 .join(product.game, game)
                 .groupBy(game.name)
                 .fetch();
 
-        List<GameTotalPriceDTO> fetch1 = queryFactory
-                .select(new QGameTotalPriceDTO(game.name, account.price.sum()))
+        List<GamePriceDTO> fetch1 = queryFactory
+                .select(new QGamePriceDTO(game.name, account.price.sum()))
                 .from(account)
                 .join(account.product, product)
                 .join(product.game, game)
@@ -443,16 +443,16 @@ class StatisticsServiceTest {
         List<GameRatioDTO> ratioEachGameDTOList = new ArrayList<>();
 
         List<Double> percentageList = new ArrayList<>();
-        fetch.forEach(gameTotalPriceDTO -> {
-            ratioEachGameDTOList.add(new GameRatioDTO(gameTotalPriceDTO.getGameName(), totalPrice, gameTotalPriceDTO.getPrice()));
+        fetch.forEach(gamePriceDTO -> {
+            ratioEachGameDTOList.add(new GameRatioDTO(gamePriceDTO.getGameName(), totalPrice, gamePriceDTO.getPrice()));
 //            percentageList.add(Math.round((double) gameTotalPriceDTO.getPrice() / totalPrice * 100.0 * 100.0) / 100.0);
         });
 //        Assertions.assertThat(percentageList.size()).isEqualTo(2);
         Assertions.assertThat(ratioEachGameDTOList.get(1).getPercentage()).isEqualTo(97.54);
     }
 
-    private double totalPrice(List<GameTotalPriceDTO> priceDTOList) {
-        return priceDTOList.stream().mapToInt(GameTotalPriceDTO::getPrice).sum();
+    private double totalPrice(List<GamePriceDTO> priceDTOList) {
+        return priceDTOList.stream().mapToInt(GamePriceDTO::getPrice).sum();
     }
 
 }


### PR DESCRIPTION
- platformIds를 필수 request 값으로 수정
- List<GamePriceDTO> 가공 시 해당 리스트에 값이 없을 경우 gameRatioList는 빈 배열로 응답
- 백분위 비율은 GameRatioDTO 생성 시 계산
- List<String> getPlatformNames 를 통해 platform들의 이름 추출하는 로직 추가
